### PR TITLE
Fixes #1: Create PowerShell installer script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,21 @@ The main use-case is figuring out how infix operators are parsed:
 
 Tada!
 
-## Setup
+## Setup (Linux, macOS)
 
 Install the package by running:
 
     git clone https://github.com/commercialhaskell/describe.git
     cd describe
     sh global-install.sh # requires stack
+
+## Setup (Windows)
+
+From a PowerShell terminal, install the package by running:
+
+    git clone https://github.com/commercialhaskell/describe.git
+    cd describe
+    .\global-install.ps1 # requires stack
 
 ## Pitfalls
 

--- a/global-install.ps1
+++ b/global-install.ps1
@@ -1,0 +1,12 @@
+# Installs globally to your GHC's global package database
+
+stack install
+
+stack exec --no-ghc-package-path -- runhaskell Setup.hs clean
+stack exec --no-ghc-package-path -- runhaskell Setup.hs configure --package-db $(stack path --global-pkg-db) --prefix=$(stack path --programs)/ghc-$(stack exec -- ghc --numeric-version)
+stack exec --no-ghc-package-path -- runhaskell Setup.hs build
+stack exec --no-ghc-package-path -- runhaskell Setup.hs install
+
+# Copy .ghci
+
+cat .ghci >> ~/.ghci


### PR DESCRIPTION
It turns out that the existing `.sh` shell script is also a completely valid PowerShell script. This revision makes a copy of the script but with the `.ps1` extension for Windows users.
